### PR TITLE
Add ability to specify additional extensions for the Path Segment File…

### DIFF
--- a/src/Dialogs/NestingOptions.cs
+++ b/src/Dialogs/NestingOptions.cs
@@ -20,9 +20,15 @@ namespace MadsKristensen.FileNesting
 
         [LocDisplayName("Enable path segment rule")]
         [Description("Files with an added path segment nests under parent. Example: foo.min.js nests under foo.js")]
-        [Category("Nesting rules")]
+        [Category("Path Segment")]
         [DefaultValue(true)]
         public bool EnablePathSegmentRule { get; set; }
+
+        [LocDisplayName("Path segment extensions")]
+        [Description("Additional Extensions (comma separated)")]
+        [Category("Path Segment")]
+        [DefaultValue("")]
+        public string PathSegmentAddedExtension { get; set; }
 
         [LocDisplayName("Enable .bundle file rule")]
         [Description("Files with .bundle extension will be parent. Example: foo.js.bundle will nest foo.js under it")]

--- a/src/Nesters/Automated/PathSegmentFileNester.cs
+++ b/src/Nesters/Automated/PathSegmentFileNester.cs
@@ -32,17 +32,21 @@ namespace MadsKristensen.FileNesting
             return NestingResult.Continue;
         }
 
-        private static bool IsSupported(string fileName)
+        private bool IsSupported(string fileName)
         {
             string extension = Path.GetExtension(fileName).ToLowerInvariant();
-            string[] allowed = new[] { ".js", ".css", ".html", ".htm", ".less", ".scss", ".coffee", ".iced", ".config", ".cs", "vb" };
-
-            return allowed.Contains(extension);
+            string[] allowed = new[] { ".js", ".css", ".html", ".htm", ".less", ".scss", ".coffee", ".iced", ".config", ".cs", "vb"};
+            var added = AdditionalExtensions();
+            return allowed.Contains(extension) || added.Contains(extension);
         }
 
         public bool IsEnabled()
         {
             return FileNestingPackage.Options.EnablePathSegmentRule;
+        }
+        public string[] AdditionalExtensions()
+        {
+            return FileNestingPackage.Options.PathSegmentAddedExtension.Split(',');
         }
     }
 }


### PR DESCRIPTION
I have a need to nest .sql files using the Page Segment File Nester
![image](https://cloud.githubusercontent.com/assets/10691236/14224073/ec322a20-f843-11e5-96ea-18e21fc63142.png)

I create different versions of a SQL file, and want them all to stack under the current version (the one without the Vx.

The Page Segment File nester works exactly how I want it to, but there is currently no way to add the .sql extension to the allowed files.

![image](https://cloud.githubusercontent.com/assets/10691236/14224079/3305e702-f844-11e5-93a4-2c0fcdf6fc0e.png)
 I added the ability to do this by adding a comma separated list of extensions in the options dialog.

I was inspired by your extensions talk today at Build, and this is my first attempt at any contributions to open source, so please be kind.

Thanks,
Duane