### PR TITLE
Support for shared projects

### DIFF
--- a/src/Helpers/Helpers.cs
+++ b/src/Helpers/Helpers.cs
@@ -93,6 +93,7 @@ namespace MadsKristensen.FileNesting
         public const string UNIVERSAL_APP = "{262852C6-CD72-467D-83FE-5EEB1973A190}";
         public const string NODE_JS = "{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}";
         public const string SSDT = "{00d1a9c2-b5f0-4af3-8072-f6c62b433612}";
+        public const string SHARED_PROJECT = "{D954291E-2A0B-460D-934E-DC6B0785DB48}";
     }
 
 }

--- a/src/Nesters/Automated/KnownFileTypeNester.cs
+++ b/src/Nesters/Automated/KnownFileTypeNester.cs
@@ -7,7 +7,7 @@ namespace MadsKristensen.FileNesting
     internal class KnownFileTypeNester : IFileNester
     {
         private static Dictionary<string, string[]> _mapping = new Dictionary<string, string[]>(){
-            {".js", new [] {".coffee", ".litcoffee", ".iced", ".ts", ".tsx", ".dart", ".html", ".cshtml", ".vbhtml", ".aspx", ".master", ".ascx"}},
+            {".js", new [] {".coffee", ".litcoffee", ".iced", ".ts", ".tsx", ".dart", ".html", ".cshtml", ".vbhtml", ".aspx", ".master", ".ascx", ".vue"}},
             {".css", new [] {".less", ".scss", ".sass", ".styl", ".html", ".cshtml", ".vbhtml", ".aspx", ".master", ".ascx"}},
             {".ts", new [] {".html", ".cshtml", ".vbhtml", ".aspx", ".master", ".ascx"}},
             {".map", new [] {".js", ".css"}},

--- a/src/Nesters/Automated/PathSegmentFileNester.cs
+++ b/src/Nesters/Automated/PathSegmentFileNester.cs
@@ -35,7 +35,7 @@ namespace MadsKristensen.FileNesting
         private static bool IsSupported(string fileName)
         {
             string extension = Path.GetExtension(fileName).ToLowerInvariant();
-            string[] allowed = new[] { ".js", ".css", ".html", ".htm", ".less", ".scss", ".coffee", ".iced", ".config", ".cs", "vb", ".sql" };
+            string[] allowed = new[] { ".js", ".css", ".html", ".htm", ".less", ".scss", ".coffee", ".iced", ".config", ".cs", "vb", ".sql", ".vue" };
 
             return allowed.Contains(extension);
         }

--- a/src/Nesters/ManualNester.cs
+++ b/src/Nesters/ManualNester.cs
@@ -22,7 +22,8 @@ namespace MadsKristensen.FileNesting
                 ProjectItem parent = item.DTE.Solution.FindProjectItem(selector.SelectedFile);
                 if (parent == null) continue;
 
-                bool mayNeedAttributeSet = item.ContainingProject.IsKind(ProjectTypes.DOTNET_Core, ProjectTypes.UNIVERSAL_APP);
+                bool mayNeedAttributeSet = item.ContainingProject.IsKind(ProjectTypes.DOTNET_Core, ProjectTypes.UNIVERSAL_APP, ProjectTypes.SHARED_PROJECT);
+
                 if (mayNeedAttributeSet)
                 {
                     SetDependentUpon(item, parent.Name);


### PR DESCRIPTION
In my case, I need to nest .js files underneath .vue files on my Shared Project (yep, I use it as a pure javascript object because it is the best VS can do in terms of speed and is pretty non invasive (i.e.: there is no bin/obj folders, just my code)).

What I did was to debug to check what ProjectGuid was for Shared C# Project and include that on the Nest option as DependentUpon. Works like a charm.